### PR TITLE
Enable battery backup when setting time, fix compatibility with Time.h and add a function to check if time is set

### DIFF
--- a/MCP7940.cpp
+++ b/MCP7940.cpp
@@ -120,6 +120,11 @@ long DateTime::get()const{
 	Date:		August 2014
 */
 
+void RTC_MCP7940::begin(){
+  Wire.begin();
+}
+
+
 void RTC_MCP7940::adjust(const DateTime& dt) {	//change date and time registers based on user input
   Wire.beginTransmission(RTC_ADD);
   Wire.write((byte) 0);

--- a/MCP7940.cpp
+++ b/MCP7940.cpp
@@ -112,9 +112,9 @@ long DateTime::get()const{
 
 /*	END SECTION COPIED FROM RTClib */
 
-/*	THIS SECTION BASED ON RTClib 
+/*	THIS SECTION BASED ON RTClib
 	It has been adjusted to support the Microchip MCP7940M
-	
+
 	Version:	Initial
 	Author:		C.Koiter
 	Date:		August 2014
@@ -146,7 +146,7 @@ DateTime RTC_MCP7940::now(){					//current date and time
   uint8_t d = bcd2bin(Wire.read());
   uint8_t m = bcd2bin(Wire.read());
   uint16_t y = bcd2bin(Wire.read()) + 2000;
-  
+
   return DateTime (y, m, d, hh, mm, ss);
 }
 

--- a/MCP7940.cpp
+++ b/MCP7940.cpp
@@ -100,7 +100,7 @@ DateTime::DateTime (const char* date, const char* time) {
   ss=conv2d(time+6);
 }
 
-uint8_t DateTime::dayOfWeek() const{
+uint8_t DateTime::DayOfWeek() const{
   uint16_t day = get()/SECONDS_PER_DAY;
   return (day+6)%7;
 }

--- a/MCP7940.cpp
+++ b/MCP7940.cpp
@@ -125,18 +125,28 @@ void RTC_MCP7940::begin(){
 }
 
 
+
+
 void RTC_MCP7940::adjust(const DateTime& dt) {	//change date and time registers based on user input
   Wire.beginTransmission(RTC_ADD);
   Wire.write((byte) 0);
   Wire.write(bin2bcd((byte) 10000000));
   Wire.write(bin2bcd(dt.minute()));
   Wire.write(bin2bcd(dt.hour()));
-  Wire.write(bin2bcd(0));
+  Wire.write(bin2bcd(0x8)); //enable RTC battery backup function
   Wire.write(bin2bcd(dt.day()));
   Wire.write(bin2bcd(dt.month()));
   Wire.write(bin2bcd(dt.year()-2000));
   Wire.write((byte) 0);
   Wire.endTransmission();
+}
+
+bool RTC_MCP7940::isset(){		//check whether clock is set
+  Wire.beginTransmission(RTC_ADD);
+  Wire.write((byte) 0);
+  Wire.endTransmission();
+  Wire.requestFrom(RTC_ADD,1);
+  return ((Wire.read()&(1<<7))==(1<<7));
 }
 
 DateTime RTC_MCP7940::now(){					//current date and time

--- a/MCP7940.cpp
+++ b/MCP7940.cpp
@@ -1,5 +1,5 @@
 /*	library based on jeelabs RTClib [original library at https://github.com/jcw/rtclib ] altered to support Microchip MCP7940M RTC, used in Arduino 
-	based embedded environments. To use this library, add #include <mcp7940.h> to the top of your program.*/
+	based embedded environments. To use this library, add #include <MCP7940.h> to the top of your program.*/
 
 #include <Wire.h>
 #ifndef ENERGIA
@@ -9,7 +9,7 @@
 #define pgm_read_byte(data) *data
 #define PROGMEM
 #endif
-#include <mcp7940.h>
+#include <MCP7940.h>
 #include <Arduino.h>
 
 #define RTC_ADD           0x6F

--- a/MCP7940.h
+++ b/MCP7940.h
@@ -25,13 +25,14 @@ class DateTime {	//DateTime class constructs the variable to store RTC Date and 
 class RTC_MCP7940{	//RTC functions, based off original library. Some functions are designed specifically for use in the
   public:			//3 Channel Data Logger.
 
-  static void begin(){};												//not sure if this is entirely necessary, no use in cpp file
+  static void begin();												//initialize Wire library
   static void adjust(const DateTime& dt);								//change date and time
   static DateTime now();												//get current time and date from RTC registers
   static uint8_t isrunning();											//check to make sure clock is ticking
   static void configure(uint8_t value);									//configure alarm enables and MFP output
   static void setAlarm(uint8_t value);									//configure alarm settings register
   static uint8_t ordinalDate(uint8_t toDay, uint8_t toMonth);			//convert date and month to ordinal (julian) date
+  static unsigned long get(){return now().get();}
 
   static uint8_t bcd2bin (uint8_t val) { return val - 6 * (val >> 4);}	//bcd to bin conv (RTC to MCU)
   static uint8_t bin2bcd (uint8_t val) { return val + 6 * (val / 10);}	//bin to bcd conv (MCU to RTC)

--- a/MCP7940.h
+++ b/MCP7940.h
@@ -1,5 +1,5 @@
 /*	library based on jeelabs RTClib [original library at https://github.com/jcw/rtclib ] altered to support Microchip MCP7940M RTC, used in Arduino
-	based embedded environments. To use this library, add #include <mcp7940.h> to the top of your program.*/
+	based embedded environments. To use this library, add #include <MCP7940.h> to the top of your program.*/
 
 class DateTime {	//DateTime class constructs the variable to store RTC Date and Time, and is a direct copy from the original RTClib.
   public:

--- a/MCP7940.h
+++ b/MCP7940.h
@@ -14,7 +14,7 @@ class DateTime {	//DateTime class constructs the variable to store RTC Date and 
   uint8_t hour() const   {return hh;}
   uint8_t minute() const {return mm;}
   uint8_t second() const {return ss;}
-  uint8_t dayOfWeek() const;
+  uint8_t DayOfWeek() const;
 
   long get() const;
 

--- a/MCP7940.h
+++ b/MCP7940.h
@@ -30,6 +30,7 @@ class RTC_MCP7940{	//RTC functions, based off original library. Some functions a
   static DateTime now();												//get current time and date from RTC registers
   static uint8_t isrunning();											//check to make sure clock is ticking
   static void configure(uint8_t value);									//configure alarm enables and MFP output
+  static bool isset();									//check whether clock has been set
   static void setAlarm(uint8_t value);									//configure alarm settings register
   static uint8_t ordinalDate(uint8_t toDay, uint8_t toMonth);			//convert date and month to ordinal (julian) date
   static unsigned long get(){return now().get();}

--- a/MCP7940.h
+++ b/MCP7940.h
@@ -1,13 +1,13 @@
-/*	library based on jeelabs RTClib [original library at https://github.com/jcw/rtclib ] altered to support Microchip MCP7940M RTC, used in Arduino 
+/*	library based on jeelabs RTClib [original library at https://github.com/jcw/rtclib ] altered to support Microchip MCP7940M RTC, used in Arduino
 	based embedded environments. To use this library, add #include <mcp7940.h> to the top of your program.*/
 
 class DateTime {	//DateTime class constructs the variable to store RTC Date and Time, and is a direct copy from the original RTClib.
-  public:			
-  
+  public:
+
   DateTime(long t =0);
   DateTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour=0, uint8_t min=0, uint8_t sec=0);
   DateTime(const char* date, const char* time);
-  
+
   uint16_t year() const  {return 2000+yOff;}
   uint8_t month() const  {return m;}
   uint8_t day() const    {return d;}
@@ -15,24 +15,24 @@ class DateTime {	//DateTime class constructs the variable to store RTC Date and 
   uint8_t minute() const {return mm;}
   uint8_t second() const {return ss;}
   uint8_t dayOfWeek() const;
-  
+
   long get() const;
-  
+
   protected:
   uint8_t yOff, m, d, hh, mm, ss;
 };
 
-class RTC_MCP7940{	//RTC functions, based off original library. Some functions are designed specifically for use in the 
+class RTC_MCP7940{	//RTC functions, based off original library. Some functions are designed specifically for use in the
   public:			//3 Channel Data Logger.
-  
+
   static void begin(){};												//not sure if this is entirely necessary, no use in cpp file
   static void adjust(const DateTime& dt);								//change date and time
   static DateTime now();												//get current time and date from RTC registers
   static uint8_t isrunning();											//check to make sure clock is ticking
-  static void configure(uint8_t value);									//configure alarm enables and MFP output 
+  static void configure(uint8_t value);									//configure alarm enables and MFP output
   static void setAlarm(uint8_t value);									//configure alarm settings register
   static uint8_t ordinalDate(uint8_t toDay, uint8_t toMonth);			//convert date and month to ordinal (julian) date
-  
+
   static uint8_t bcd2bin (uint8_t val) { return val - 6 * (val >> 4);}	//bcd to bin conv (RTC to MCU)
   static uint8_t bin2bcd (uint8_t val) { return val + 6 * (val / 10);}	//bin to bcd conv (MCU to RTC)
 };

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,3 +14,5 @@ isrunning	KEYWORD2
 configure	KEYWORD2
 setAlarm	KEYWORD2
 ordinalDate	KEYWORD2
+get		KEYWORD2
+isset		KEYWORD2


### PR DESCRIPTION
Thanks for writing this library. I used it in a project this week and ran into some issues with it which I've fixed in these commits. Here are the problems I fixed:
- Header file is named MCP7940.h but the #include specifies mcp7940.h. This doesn't work on case-sensitive operating systems. I changed the #include to MCP7940.h.
- Arduino's Time.h defines a dayOfWeek #define, which causes strange compilation errors if Time.h is included beofre MCP7940.h. I renamed the function to DayOfWeek to work around this.
- There was no way to use this library with Time.h's setSyncProvider. I added a .get() function to fix that.
- The begin function was empty - it needs to call Wire.begin() unless the i2c bus has already been initialized. If this device is the only i2c device on the bus, it's very unlikely that the i2c peripheral has been initialized, so we need to do it in .begin()
- The adjust function accidentally disables the RTC battery backup, so the clock is reset on power down even if a battery is connected. I changed it to enable the VBATEN bit when the clock is adjusted
- When the clock is reset, the oscillator is disabled. I added a function to check whether the clock is running, which means it has been adjusted. This allows users to check if the time needs to be set and do so, or at least mark the time as invalid.

Again, thank you so much for writing this, it saved me a lot of time!
